### PR TITLE
lxc-changeid

### DIFF
--- a/lxc-changeid/lxc-changeid
+++ b/lxc-changeid/lxc-changeid
@@ -47,48 +47,48 @@ parse_options() {
 check_exist() {
    test $(ls -ald /etc/pve/nodes/*/{lxc,qemu-server}/$NEWID.conf 2>/dev/null | wc -l) -ne 0 && {
       echo "ERROR: The destination ID already exists!"
-		exit 1
+      exit 1
    }
 }
 
 change_id() {
-	test $force -ne 1 && read -p "You are going to move $OLDID to $NEWID, are you sure? [y/N]" RESPONSE
+   test $force -ne 1 && read -p "You are going to move $OLDID to $NEWID, are you sure? [y/N]" RESPONSE
 
-	case $RESPONSE in
-	[yY])
-		cd /etc/pve/lxc
+   case $RESPONSE in
+   [yY])
+      cd /etc/pve/lxc
 
       OLDDISK=$(grep rootfs $OLDID.conf | awk '{print $2}' | cut -d, -f1)
 
       # Get the path in the ZFS pool for the disk and remove leading /
       OLDDISK_PATH=$(pvesm path $OLDDISK | sed 's#/##')
 
-		NEWDISK=$(echo $OLDDISK | sed "s/-$OLDID-/-$NEWID-/")
-		NEWDISK_PATH=$(echo $OLDDISK_PATH | sed "s/-$OLDID-/-$NEWID-/")
+      NEWDISK=$(echo $OLDDISK | sed "s/-$OLDID-/-$NEWID-/")
+      NEWDISK_PATH=$(echo $OLDDISK_PATH | sed "s/-$OLDID-/-$NEWID-/")
 
-		test $(grep subvol $OLDID.conf| wc -l) -ge 2 && MULTIMOUNTS=1
+      test $(grep subvol $OLDID.conf| wc -l) -ge 2 && MULTIMOUNTS=1
 
-		test $verbose -eq 1 && echo "INFO: Stopping CT $OLDID"
+      test $verbose -eq 1 && echo "INFO: Stopping CT $OLDID"
       test $(pct status $OLDID | awk '{print $2}') == "running" && {
-		   pct stop $OLDID
+         pct stop $OLDID
       }
 
-		test $verbose -eq 1 && echo "INFO: Renaming rootfs"
-		zfs rename $OLDDISK_PATH $NEWDISK_PATH
+      test $verbose -eq 1 && echo "INFO: Renaming rootfs"
+      zfs rename $OLDDISK_PATH $NEWDISK_PATH
 
-		test $verbose -eq 1 && echo "INFO: Updating configuration"
-		sed -i "s/-$OLDID-/-$NEWID-/" $OLDID.conf 2>/dev/null
-		mv $OLDID.conf $NEWID.conf
+      test $verbose -eq 1 && echo "INFO: Updating configuration"
+      sed -i "s/-$OLDID-/-$NEWID-/" $OLDID.conf 2>/dev/null
+      mv $OLDID.conf $NEWID.conf
 
-		test $MULTIMOUNTS -eq 1 && {
-			echo "WARNING: This container has multiple mounts, please check them, not starting container"
+      test $MULTIMOUNTS -eq 1 && {
+         echo "WARNING: This container has multiple mounts, please check them, not starting container"
          canrun=0
       }
-		;;
-	*)
-		echo "Aborting..."
-		exit 1
-		;;
+      ;;
+   *)
+      echo "Aborting..."
+      exit 1
+      ;;
    esac
 }
 

--- a/lxc-changeid/lxc-changeid
+++ b/lxc-changeid/lxc-changeid
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
 # lxc-changeid: change id for a given LXC container
-MULTIMOUNTS=false
 
 usage() {
    echo "Usage: lxc-changeid <options> [current] [new]"
@@ -10,9 +9,8 @@ usage() {
    echo "This script will only update the rootfs for the container."
    echo "Any extra/custom mounts have to be updated manually!"
    echo
-   echo "The container will be restarted if it's running, use -s and -n"
-   echo "to override this behaviour. A running container will be stopped and"
-   echo "started."
+   echo "The container will be started if it's possible, use -s and -n"
+   echo "to override this behaviour."
    echo
    echo "   -f       Force, do not ask for confirmation"
    echo "   -n       Do not start the container"
@@ -22,13 +20,15 @@ usage() {
 }
 
 parse_options() {
-   while getopts :fsv opt
+   while getopts :fnsv opt
    do
       case $opt in
          f) force=1
             RESPONSE=Y
          ;;
-         s) run=1
+         n) wantrun=0
+         ;;
+         s) wantrun=1
          ;;
          v) verbose=1
          ;;
@@ -66,11 +66,10 @@ change_id() {
 		NEWDISK=$(echo $OLDDISK | sed "s/-$OLDID-/-$NEWID-/")
 		NEWDISK_PATH=$(echo $OLDDISK_PATH | sed "s/-$OLDID-/-$NEWID-/")
 
-		[ $(grep subvol $OLDID.conf| wc -l) -ge 2 ] && MULTIMOUNTS=true
+		[ $(grep subvol $OLDID.conf| wc -l) -ge 2 ] && MULTIMOUNTS=1
 
 		test $verbose -eq 1 && echo "INFO: Stopping CT $OLDID"
       test $(pct status $OLDID | awk '{print $2}') == "running" && {
-         run=1
 		   pct stop $OLDID
       }
 
@@ -81,13 +80,10 @@ change_id() {
 		sed -i "s/-$OLDID-/-$NEWID-/" $OLDID.conf 2>/dev/null
 		mv $OLDID.conf $NEWID.conf
 
-		$MULTIMOUNTS && {
+		test $MULTIMOUNTS -eq 1 && {
 			echo "WARNING: This container has multiple mounts, please check them, not starting container"
-		} || {
-			test $verbose -eq 1 && echo "INFO: Starting CT $NEWID"
-			test $run -eq 1 && pct start $NEWID
-		}
-
+         canrun=0
+      }
 		;;
 	*)
 		echo "Aborting..."
@@ -99,13 +95,20 @@ change_id() {
 main() {
    force=0
    verbose=0
-   run=0
+   canrun=1
+   wantrun=1
+   MULTIMOUNTS=0
 
    parse_options "$@"
 
    check_exist
 
    change_id
+
+   test $canrun -eq 1 && test $wantrun -eq 1 && {
+      test $verbose -eq 1 && echo "INFO: Starting CT $NEWID"
+      pct start $NEWID
+   }
 }
 
 main "$@"

--- a/lxc-changeid/lxc-changeid
+++ b/lxc-changeid/lxc-changeid
@@ -45,7 +45,7 @@ parse_options() {
 }
 
 check_exist() {
-   [ $(ls -ald /etc/pve/nodes/*/{lxc,qemu-server}/$NEWID.conf 2>/dev/null | wc -l) -ne 0 ] && {
+   test $(ls -ald /etc/pve/nodes/*/{lxc,qemu-server}/$NEWID.conf 2>/dev/null | wc -l) -ne 0 && {
       echo "ERROR: The destination ID already exists!"
 		exit 1
    }
@@ -66,7 +66,7 @@ change_id() {
 		NEWDISK=$(echo $OLDDISK | sed "s/-$OLDID-/-$NEWID-/")
 		NEWDISK_PATH=$(echo $OLDDISK_PATH | sed "s/-$OLDID-/-$NEWID-/")
 
-		[ $(grep subvol $OLDID.conf| wc -l) -ge 2 ] && MULTIMOUNTS=1
+		test $(grep subvol $OLDID.conf| wc -l) -ge 2 && MULTIMOUNTS=1
 
 		test $verbose -eq 1 && echo "INFO: Stopping CT $OLDID"
       test $(pct status $OLDID | awk '{print $2}') == "running" && {

--- a/lxc-changeid/lxc-changeid
+++ b/lxc-changeid/lxc-changeid
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# lxc-changeid: change id for a given LXC container
+MULTIMOUNTS=false
+
+usage() {
+   echo "Usage: lxc-changeid <options> [current] [new]"
+   echo "changes the CTID of a LXC container with storage based on a ZFS subvol"
+   echo
+   echo "This script will only update the rootfs for the container."
+   echo "Any extra/custom mounts have to be updated manually!"
+   echo
+   echo "   -f       Force, do not ask for confirmation"
+   echo "   -s       Start the container if it is not"
+   echo "   -v       Be more verbose."
+   exit 1
+}
+
+parse_options() {
+   while getopts :fsv opt
+   do
+      case $opt in
+         f) force=1
+            RESPONSE=Y
+         ;;
+         s) run=1
+         ;;
+         v) verbose=1
+         ;;
+         \?) echo "Unknowing options: -$OPTARG"
+             usage
+         ;;
+      esac
+   done
+   shift $((OPTIND -1))
+
+   test $# -ne 2 && { echo "Two arguments required."; exit 1; }
+   OLDID=$1
+   NEWID=$2
+}
+
+check_exist() {
+   [ $(ls -ald /etc/pve/nodes/*/{lxc,qemu-server}/$NEWID.conf 2>/dev/null | wc -l) -ne 0 ] && {
+      echo "ERROR: The destination ID already exists!"
+		exit 1
+   }
+}
+
+change_id() {
+	test $force -ne 1 && read -p "You are going to move $OLDID to $NEWID, are you sure? [y/N]" RESPONSE
+
+	case $RESPONSE in
+	[yY])
+		cd /etc/pve/lxc
+
+      OLDDISK=$(grep rootfs $OLDID.conf | awk '{print $2}' | cut -d, -f1)
+
+      # Get the path in the ZFS pool for the disk and remove leading /
+      OLDDISK_PATH=$(pvesm path $OLDDISK | sed 's#/##')
+
+		NEWDISK=$(echo $OLDDISK | sed "s/-$OLDID-/-$NEWID-/")
+		NEWDISK_PATH=$(echo $OLDDISK_PATH | sed "s/-$OLDID-/-$NEWID-/")
+
+		[ $(grep subvol $OLDID.conf| wc -l) -ge 2 ] && MULTIMOUNTS=true
+
+		test $verbose -eq 1 && echo "INFO: Stopping CT $OLDID"
+      test $(pct status $OLDID | awk '{print $2}') == "running" && {
+         run=1
+		   pct stop $OLDID
+      }
+
+		test $verbose -eq 1 && echo "INFO: Renaming rootfs"
+		zfs rename $OLDDISK_PATH $NEWDISK_PATH
+
+		test $verbose -eq 1 && echo "INFO: Updating configuration"
+		sed -i "s/-$OLDID-/-$NEWID-/" $OLDID.conf 2>/dev/null
+		mv $OLDID.conf $NEWID.conf
+
+		$MULTIMOUNTS && {
+			echo "WARNING: This container has multiple mounts, please check them, not starting container"
+		} || {
+			test $verbose -eq 1 && echo "INFO: Starting CT $NEWID"
+			test $run -eq 1 && pct start $NEWID
+		}
+
+		;;
+	*)
+		echo "Aborting..."
+		exit 1
+		;;
+   esac
+}
+
+main() {
+   force=0
+   verbose=0
+   run=0
+
+   parse_options "$@"
+
+   check_exist
+
+   change_id
+}
+
+main "$@"

--- a/lxc-changeid/lxc-changeid
+++ b/lxc-changeid/lxc-changeid
@@ -10,8 +10,13 @@ usage() {
    echo "This script will only update the rootfs for the container."
    echo "Any extra/custom mounts have to be updated manually!"
    echo
+   echo "The container will be restarted if it's running, use -s and -n"
+   echo "to override this behaviour. A running container will be stopped and"
+   echo "started."
+   echo
    echo "   -f       Force, do not ask for confirmation"
-   echo "   -s       Start the container if it is not"
+   echo "   -n       Do not start the container"
+   echo "   -s       Start the container"
    echo "   -v       Be more verbose."
    exit 1
 }
@@ -34,7 +39,7 @@ parse_options() {
    done
    shift $((OPTIND -1))
 
-   test $# -ne 2 && { echo "Two arguments required."; exit 1; }
+   test $# -ne 2 && { echo "ERROR: Two arguments required."; usage; }
    OLDID=$1
    NEWID=$2
 }


### PR DESCRIPTION
The script will check if there is a duplicate ID for other LXC/Qemu VM's and it will renumber the container accordingly.

By default, the script will attempt to run the container under it's new ID, but this can be overriden.

I've tried to match the coding style for the other scripts :-)